### PR TITLE
Gemfile.lock changes from bundling latest

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: git://github.com/RISCfuture/composite_primary_keys.git
+  revision: c947ca9d255a9e5854072b3567c4368d5891cacb
+  specs:
+    composite_primary_keys (5.0.7)
+      activerecord (~> 3.2.0)
+
+GIT
   remote: git://github.com/RISCfuture/has_metadata_column.git
   revision: 2aebf034ab97365cfbf56073c24c3a28fe2dc4ae
   specs:
@@ -7,21 +14,14 @@ GIT
       rails (>= 3.0)
 
 GIT
-  remote: git@github.com:RISCfuture/composite_primary_keys.git
-  revision: c947ca9d255a9e5854072b3567c4368d5891cacb
-  specs:
-    composite_primary_keys (5.0.7)
-      activerecord (~> 3.2.0)
-
-GIT
-  remote: git@github.com:RISCfuture/ruby-git.git
+  remote: git://github.com/RISCfuture/ruby-git.git
   revision: 473d8ecc1fd49cbfcbabff0061484319d4bac9fa
   specs:
     git (1.2.5)
 
 GIT
-  remote: git@github.com:rails/rails.git
-  revision: 11f5debcd5bbfaf51d2d2f24f2c5cee38f37fcdb
+  remote: git://github.com/rails/rails.git
+  revision: a3aca81b21f793e8869440e9e84ead80c2479e3d
   branch: 3-2-stable
   specs:
     actionmailer (3.2.11)


### PR DESCRIPTION
Changing the git-sources of gems changes the `Gemfile.lock` the next time a bundle is run.  
