### PR TITLE
LDAP Authentication Failure: Connection reset by peer

### DIFF
--- a/app/controllers/additions/ldap_authentication_helpers.rb
+++ b/app/controllers/additions/ldap_authentication_helpers.rb
@@ -42,7 +42,7 @@ module LdapAuthenticationHelpers
       ldap.auth Squash::Configuration.authentication.ldap.bind_dn, Squash::Configuration.authentication.ldap.bind_password
       if ldap.bind
         if (entry = locate_ldap_user(ldap, username))
-          ldap.auth entry[:dn], password
+          ldap.auth entry.dn, password
           unless ldap.bind
             logger.tagged('AuthenticationHelpers') { logger.info "Denying login to #{username}: LDAP authentication failed." }
             return false

--- a/spec/controllers/additions/ldap_authentication_helpers_spec.rb
+++ b/spec/controllers/additions/ldap_authentication_helpers_spec.rb
@@ -39,6 +39,7 @@ if Squash::Configuration.authentication.strategy == 'ldap'
             sn:        'Bar',
             dn:        "#{Squash::Configuration.authentication.ldap.search_key}=#{@user.username},#{Squash::Configuration.authentication.ldap.tree_base}"
         }
+        entry.stub(:dn).and_return(entry[:dn])
 
         @ldap.should_receive(:search).once do |hsh|
           hsh[:filter].to_raw_rfc2254 == "#{Squash::Configuration.authentication.ldap.search_key}=#{@user.username}"
@@ -65,6 +66,7 @@ if Squash::Configuration.authentication.strategy == 'ldap'
             sn:        'Bar',
             dn:        "#{Squash::Configuration.authentication.ldap.search_key}=#{@user.username},#{Squash::Configuration.authentication.ldap.tree_base}"
         }
+        entry.stub(:dn).and_return(entry[:dn])
 
         @ldap.should_receive(:search).once do |hsh|
           hsh[:filter].to_raw_rfc2254 == "#{Squash::Configuration.authentication.ldap.search_key}=#{@user.username}"
@@ -112,6 +114,7 @@ if Squash::Configuration.authentication.strategy == 'ldap'
               sn:        'Bar',
               dn:        "#{Squash::Configuration.authentication.ldap.search_key}=#{@user.username},#{Squash::Configuration.authentication.ldap.tree_base}"
           }
+          entry.stub(:dn).and_return(entry[:dn])
 
           @ldap.should_receive(:search).once do |hsh|
             hsh[:filter].to_raw_rfc2254 == "#{Squash::Configuration.authentication.ldap.search_key}=#{@user.username}"
@@ -157,6 +160,7 @@ if Squash::Configuration.authentication.strategy == 'ldap'
             sn:        'User',
             dn:        "#{Squash::Configuration.authentication.ldap.search_key}=newuser,#{Squash::Configuration.authentication.ldap.tree_base}"
         }
+        entry.stub(:dn).and_return(entry[:dn])
 
         @ldap.should_receive(:search).once do |hsh|
           hsh[:filter].to_raw_rfc2254 == "#{Squash::Configuration.authentication.ldap.search_key}=newuser"


### PR DESCRIPTION
I'm setting up Squash to use LDAP authentication. I've been able to get all the way to the point where the LDAP auth helper is binding a second time (after locating successfully my user) with my user DN and the password.

Calling `ldap.bind` on line 46 is issuing a Connection reset by peer error. This causes the auth process to explode.

``` ruby
# app/controllers/additions/ldap_authentication_helpers.rb:43
if (entry = locate_ldap_user(ldap, username))
  ldap.auth entry[:dn], password
  unless ldap.bind
    logger.tagged('AuthenticationHelpers') { logger.info "Denying login to #{username}: LDAP authentication failed." }
    return false
  end
else
...
```

I've put a `binding.pry` in just after the `entry` var is assigned, and it's `:dn` appears to be valid, and the `password` var does contain the appropriate password.

The following log is from when I rescued the exception and printed it's message, the `ldap.get_operation_result`, and the backtrace:

```
[LDAP Bind Failure] Connection reset by peer
[LDAP Bind Failure] #<OpenStruct code=0, message="Success">
[LDAP Bind Failure] /home/jamhead/.rvm/gems/ruby-1.9.3-p374@squash/gems/net-ldap-0.3.1/lib/net/ber/ber_parser.rb:157:in `getbyte'
/home/jamhead/.rvm/gems/ruby-1.9.3-p374@squash/gems/net-ldap-0.3.1/lib/net/ber/ber_parser.rb:157:in `read_ber'
/home/jamhead/.rvm/gems/ruby-1.9.3-p374@squash/gems/net-ldap-0.3.1/lib/net/ldap.rb:1238:in `bind_simple'
/home/jamhead/.rvm/gems/ruby-1.9.3-p374@squash/gems/net-ldap-0.3.1/lib/net/ldap.rb:1209:in `bind'
/home/jamhead/.rvm/gems/ruby-1.9.3-p374@squash/gems/net-ldap-0.3.1/lib/net/ldap.rb:718:in `bind'
/srv/squash/releases/20130121000001/app/controllers/additions/ldap_authentication_helpers.rb:48:in `log_in'
/srv/squash/releases/20130121000001/app/controllers/sessions_controller.rb:70:in `create'
```

I'm open to this being an LDAP issue or a misconfiguration on my side, but wondering if you have any ideas where I could go from here. If the LDAP library is to blame, we should probably be accounting for the fact that `ldap.bind` _may_ blow up.

Part of me thinks that doing multiple `bind` calls on a single LDAP object may not be supported, but it's just a guess. Thoughts?
