### PR TITLE
Handle thread pool properly under Passenger

### DIFF
--- a/config/initializers/concurrency.rb
+++ b/config/initializers/concurrency.rb
@@ -1,4 +1,16 @@
 # Spawn and stop the thread pool
 
-Multithread.start
-at_exit { Multithread.stop }
+if defined?(PhusionPassenger)
+  PhusionPassenger.on_event(:starting_worker_process) do |forked|
+    Multithread.start
+  end
+
+  PhusionPassenger.on_event(:stopping_worker_process) do
+    Multithread.stop
+  end
+
+else
+  # Not in Passenger at all
+  Multithread.start
+  at_exit { Multithread.stop }
+end


### PR DESCRIPTION
When running under Passenger, the thread pool is destroyed every time a new worker is spawned.  This change catches the Passenger fork events and starts/stops the thread pool per worker appropriately.
