### PR TITLE
Fix the condition portion on the set latest rule.

### DIFF
--- a/db/migrate/20130215185809_fix_condition_on_rule_occurrences_set_latest.rb
+++ b/db/migrate/20130215185809_fix_condition_on_rule_occurrences_set_latest.rb
@@ -1,0 +1,25 @@
+class FixConditionOnRuleOccurrencesSetLatest < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      CREATE OR REPLACE RULE occurrences_set_latest AS
+        ON INSERT TO occurrences DO
+          UPDATE bugs
+            SET latest_occurrence = NEW.occurred_at
+            WHERE (bugs.id = NEW.bug_id)
+              AND ((bugs.latest_occurrence IS NULL)
+              OR (bugs.latest_occurrence < NEW.occurred_at))
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      CREATE OR REPLACE RULE occurrences_set_latest AS
+        ON INSERT TO occurrences DO
+          UPDATE bugs
+            SET latest_occurrence = NEW.occurred_at
+            WHERE (bugs.id = NEW.bug_id)
+              AND (bugs.latest_occurrence IS NULL)
+              OR (bugs.latest_occurrence < NEW.occurred_at)
+    SQL
+  end
+end


### PR DESCRIPTION
The rule, as currently written, updates all the bugs if they occured before the new occurrence.

The updated version makes sure that it only updates the bug associated with the occurrence.
