### PR TITLE
Start threads when running under Unicorn

### DIFF
--- a/config/initializers/concurrency.rb
+++ b/config/initializers/concurrency.rb
@@ -8,7 +8,14 @@ if defined?(PhusionPassenger)
   PhusionPassenger.on_event(:stopping_worker_process) do
     Multithread.stop
   end
-
+elsif defined?(Unicorn)
+  Unicorn::HttpServer.class_eval do
+    old = instance_method(:worker_loop)
+    define_method(:worker_loop) do |worker|
+      Multithread.start
+      old.bind(self).call(worker)
+    end
+  end
 else
   # Not in Passenger at all
   Multithread.start


### PR DESCRIPTION
Default initializer did not work for me (I'm using nginx/unicorn combo to start up rails apps). I found working solution here: https://github.com/scoutapp/scout_rails/blob/master/lib/scout_rails/agent.rb#L136 
