### PR TITLE
Update Gemfile to use https

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
-source :rubygems
+source 'https://rubygems.org'
+
 ruby "1.9.3"
 
 # FRAMEWORK


### PR DESCRIPTION
Resolves following warning when bundling:

```
The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not. 
```
