### PR TITLE
Don't assume that public path is #{root}/public

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -136,7 +136,7 @@ class ApplicationController < ActionController::Base
 
   rescue_from(ActiveRecord::RecordNotFound) do
     respond_to do |format|
-      format.html { render file: Rails.root.join('public/404.html'), status: :not_found }
+      format.html { render file: File.join(Rails.public_path, '404.html'), status: :not_found }
       format.json { head :not_found }
       format.atom { head :not_found }
     end


### PR DESCRIPTION
Reflecting on the configured public directory allows custom 404 serving even when the public directory is moved (e.g. in .war files generated by warbler).
