### PR TITLE
Asset precompilation woes

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -77,6 +77,9 @@ module Squash
     # Enable the asset pipeline
     config.assets.enabled = true
 
+    # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
+    config.assets.precompile << 'flot/excanvas.js'
+
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'
     config.generators do |g|

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,9 +61,6 @@ Squash::Application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server
   # config.action_controller.asset_host = "http://assets.example.com"
 
-  # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
-  config.assets.precompile << 'flot/excanvas.js'
-
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false
 


### PR DESCRIPTION
Currently `config.assets.initialize_on_precompile` is set to true (the default). This means, if you want to precompile assets prior to a deployment (e.g. creating a war file, deploying to Heroku, or just doing the work once before sending out to many servers), you need to have access to the production DB.

Usually, to counter this, one can set `RAILS_ENV=development` before running the precompilation rake task. However, in the case of Squash, "flot/excanvas.js" is added to `config.assets.precompile` only in `config/environments/production.rb` resulting in a `ActionView::Template::Error (flot/excanvas.js isn't precompiled)` error at runtime in production.

So, there are two ways out of this that I see. I'm happy to issue a pull request for either direction, I just wanted some input first in case there is a preferred route:
1. Move `config.assets.precompile << 'flot/excanvas.js` from `production.rb` to `application.rb` so it is effective in all compilation environments (i.e. allowing precompilation with `RAILS_ENV=development`)
2. Set `config.assets.initialize_on_precompile = false` so that a DB connection is not formed. This has other issues if any of the assets access certain classes or constants at compile time (e.g. ERB assets).

For option 2, one error that already pops up is `uninitialized constant Ping` due to a lot of assumed `require`s not happening. Things like this would need to be resolved.
