### PR TITLE
Make repository clone directory configurable.

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -91,7 +91,7 @@ require 'securerandom'
 
 class Project < ActiveRecord::Base
   # The directory where repositories are checked out.
-  REPOS_DIRECTORY = File.expand_path(Squash::Configuration.project.repos_directory, Rails.root.to_s)
+  REPOS_DIRECTORY = File.expand_path(Squash::Configuration.repositories.directory, Rails.root.to_s)
   # File names that appear in backtraces that aren't really file names
   META_FILE_NAMES = %w( (irb) (eval) -e )
 

--- a/config/environments/common/project.yml
+++ b/config/environments/common/project.yml
@@ -1,2 +1,0 @@
----
-repos_directory: tmp/repos

--- a/config/environments/common/repositories.yml
+++ b/config/environments/common/repositories.yml
@@ -1,0 +1,2 @@
+---
+directory: tmp/repos


### PR DESCRIPTION
Configuration is stored in `config/environments/common/project.yml` and supports both absolute and relative (to project root) paths.

I wasn't sure of the best config file to use so just created an arbitrary one named after the model. If anybody has a suggestion for a better config name, I'd be very happy to hear it and change the implementation.
