### PR TITLE
`config/environments/common/guard_dog.yml` necessary?

### DIFF
--- a/config/environments/common/guard_dog.yml
+++ b/config/environments/common/guard_dog.yml
@@ -1,6 +1,0 @@
----
-enabled: true
-client:
-  key: /data/app/squash/secrets/squash-s2s.key
-  cert: /data/app/squash/secrets/squash-s2s.crt
-  ca: /etc/kwfs/square_root.crt


### PR DESCRIPTION
The `config/environments/common/guard_dog.yml` file seems Square-specific and I can't see any explicit reference to "guard_dog" anywhere in the repository. I'm just wondering if it can/should be removed or if it is part of something that I am missing.
