### PR TITLE
Added missing 'registration_enabled' when generating password based authentication.yml

### DIFF
--- a/setup.rb
+++ b/setup.rb
@@ -337,6 +337,7 @@ if step < 2
     File.open('config/environments/common/authentication.yml', 'w') do |f|
       f.puts({
                  'strategy' => 'password',
+                 'registration_enabled' => true,
                  'password' => {
                      'salt' => SecureRandom.base64
                  }


### PR DESCRIPTION
When starting from scratch and using password authentication
after the registration_enabled flag was added gave me a missing method since it was not defined
in authentication.yml this now works
