### PR TITLE
BackgroundRunner::Resque Module

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,3 +78,8 @@ group :test do
 end
 
 gem 'sql_origin', groups: [:development, :test]
+
+group :resque do
+  gem 'resque'
+  gem 'resque-pool'
+end

--- a/config/environments/common/concurrency.yml
+++ b/config/environments/common/concurrency.yml
@@ -18,3 +18,10 @@ multithread:
     ProjectRepoFetcher: 30
     SourceMapWorker: 60
     SymbolicationWorker: 60
+
+resque: 
+  development: localhost:6379
+  production: localhost:6379
+  test: localhost:6379
+  pool:
+    squash: 2

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -1,0 +1,8 @@
+if Squash::Configuration.concurrency.background_runner == 'Resque'
+  Bundler.require(:resque)
+  rails_root = ENV['RAILS_ROOT'] || File.dirname(__FILE__) + '/../..'
+  rails_env = ENV['RAILS_ENV'] || 'development'
+
+  config = YAML.load_file(rails_root.to_s + '/config/environments/common/concurrency.yml')
+  Resque.redis = config['resque'][rails_env]
+end

--- a/lib/background_runner.rb
+++ b/lib/background_runner.rb
@@ -29,7 +29,7 @@ module BackgroundRunner
   #   background jobs.
 
   def self.runner
-    BackgroundRunner.const_get Squash::Configuration.concurrency.background_runner.to_sym
+    BackgroundRunner.const_get Squash::Configuration.concurrency.background_runner.to_sym, false
   end
 
   # Shortcut for `BackgroundRunner.runner.run`.

--- a/lib/background_runner/resque.rb
+++ b/lib/background_runner/resque.rb
@@ -1,0 +1,10 @@
+module BackgroundRunner
+  module Resque
+    @@queue = :squash
+
+    def self.run(job_name, *arguments)
+      job_name = job_name.constantize unless job_name.kind_of?(Class)
+      ::Resque.enqueue_to(@@queue, job_name, *arguments)
+    end
+  end
+end

--- a/lib/tasks/resque.rake
+++ b/lib/tasks/resque.rake
@@ -1,0 +1,30 @@
+require 'resque/tasks'
+require 'resque/pool/tasks'
+
+# We'll override the default pool task in order to use our Squash config
+Rake::Task['resque:pool'].clear
+
+namespace :resque do
+  task :setup => :environment
+
+  task 'pool:setup' do 
+    ActiveRecord::Base.connection.disconnect!
+    Resque::Pool.after_prefork do |job|
+      ActiveRecord::Base.establish_connection
+    end
+  end
+
+  desc "Launch a pool of resque workers"
+  task :pool => %w[resque:setup resque:pool:setup] do
+    require 'resque/pool'
+    
+    rails_root = ENV['RAILS_ROOT'] || File.dirname(__FILE__) + '/../..'
+    config = YAML.load_file(rails_root.to_s + '/config/environments/common/concurrency.yml')
+
+    if GC.respond_to?(:copy_on_write_friendly=)
+      GC.copy_on_write_friendly = true
+    end
+
+    Resque::Pool.new(config['resque']['pool']).start.join
+  end
+end


### PR DESCRIPTION
Optional Resque integration using the new BackgroundRunner pattern.  Only using a single module-level Resque queue right now to avoid polluting the worker classes with @queue instance vars.  I may explore other Resque queue options later.
