### PR TITLE
Use Rack::Cors in other environments

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -88,6 +88,13 @@ module Squash
       g.integration_tool    :rspec
       g.fixture_replacement :factory_girl, dir: 'spec/factories'
     end
+
+    config.middleware.use Rack::Cors do
+      allow do
+        origins *Squash::Configuration.squash_javascript.allowed_domains
+        resource '/api/1.0/notify', headers: :any, methods: [:post]
+      end
+    end
   end
 end
 

--- a/config/environments/test/squash_javascript.yml
+++ b/config/environments/test/squash_javascript.yml
@@ -1,2 +1,3 @@
 ---
 disabled: true
+allowed_domains: []


### PR DESCRIPTION
Currently it is only configured for development, but that won't do any good for people trying to collect JS errors in production/uat/staging environments.

My suggestion would be to add something like the following to `application.rb`:

``` ruby
config.middleware.use Rack::Cors do
  allow do
    origins *Squash::Configuration.squash_javascript.allowed_domains
    resource '/api/1.0/notify', headers: :any, methods: [:post]
  end
end
```

And `config/environments/common/squash_javascript.yml`:

``` yaml

---
disabled: false
# allowed_domains: * # to allow all domains
allowed_domains: [] # to explicitly list domains
```

We could also by default add either `Squash::Configuration.javascript_dogfood[:APIHost]` and/or `Squash::Configuration.dogfood.api_host` but I think often enough they could be different than the public hostname of Squash itself (at least, I know they are in my setup), so it may just be easier to ask people to list them explicitly.

I'm about to experiment with this shortly, but if you have no objections to the general idea, I'll prepare a pull request.

(This is related to SquareSquash/javascript#2)
