### PR TITLE
Add WebDAV methods to valid request_methods.

### DIFF
--- a/app/models/occurrence.rb
+++ b/app/models/occurrence.rb
@@ -431,7 +431,7 @@ class Occurrence < ActiveRecord::Base
       orientation:            {length: {maximum: 100}, allow_nil: true},
 
       # HTTP
-      request_method:         {inclusion: {in: %w( GET POST PUT PATCH DELETE HEAD TRACE OPTIONS CONNECT PROPFIND PROPPATCH MKCOL COPY MOVE LOCK USERINFO )}, allow_nil: true},
+      request_method:         {length: {maximum: 50}, allow_nil: true},
       schema:                 {length: {maximum: 50}, allow_nil: true},
       host:                   {length: {maximum: 255}, allow_nil: true},
       port:                   {type: Fixnum, allow_nil: true},


### PR DESCRIPTION
This may be a sign that request_method shouldn't have any validation on it? I can only imagine there are other HTTP-accessible services with their own made-up verbs?
