### PR TITLE
Show request tab if there are headers *or* params.

### DIFF
--- a/app/models/occurrence.rb
+++ b/app/models/occurrence.rb
@@ -549,7 +549,7 @@ class Occurrence < ActiveRecord::Base
   #   request information.
 
   def request?
-    params? && headers?
+    params? || headers?
   end
 
   # @return [true, false] Whether or not this Occurrence has Rails information.


### PR DESCRIPTION
Otherwise, requests without parameters would show the headers on the 'user data' tab, which was less convenient.
