### PR TITLE
102 - SMTP configuration not used

### DIFF
--- a/config/initializers/mail.rb
+++ b/config/initializers/mail.rb
@@ -14,7 +14,6 @@
 
 # Configure ActionMailer
 
-#raise Squash::Configuration.mailer.strategy.inspect
 if Squash::Configuration.mailer.strategy == 'smtp'
-  ActionMailer::Base.smtp_settings = Squash::Configuration.mailer.smtp_settings
+  ActionMailer::Base.smtp_settings = Squash::Configuration.mailer.smtp_settings.symbolize_keys
 end


### PR DESCRIPTION
The SMTP configration is being added to ActionMailer with string keys
but need to be sybmolized keys. As a result, at run time the
configured SMTP settings (e.g. from
config/environments/common/mailer.yml) are ignored and the defaults are
used instead.

This symbolizes the keys that are set on
ActionMailer::Base.smtp_settings

Original issue: #102
