### PR TITLE
support simple_tls encryption mode for Net::LDAP

### DIFF
--- a/app/controllers/additions/ldap_authentication_helpers.rb
+++ b/app/controllers/additions/ldap_authentication_helpers.rb
@@ -80,10 +80,13 @@ module LdapAuthenticationHelpers
   private
 
   def build_ldap_interface
-    ldap      = Net::LDAP.new
+    ldap_opts = {}
+    if Squash::Configuration.authentication.ldap.ssl
+      ldap_opts[:encryption] = Squash::Configuration.authentication.ldap.encryption_method.to_sym || :start_tls
+    end
+    ldap      = Net::LDAP.new(ldap_opts)
     ldap.host = Squash::Configuration.authentication.ldap.host
     ldap.port = Squash::Configuration.authentication.ldap.port
-    ldap.encryption(:start_tls) if Squash::Configuration.authentication.ldap.ssl
     ldap
   end
 


### PR DESCRIPTION
Our LDAP server uses simple_tls, rather than start_tls. This change defaults to start_tls for backwards compatibility.
