### PR TITLE
Fix the bugs atom feed

### DIFF
--- a/app/views/bugs/index.atom.builder
+++ b/app/views/bugs/index.atom.builder
@@ -17,12 +17,12 @@ atom_feed(root_url: project_environment_bugs_url(@project, @environment)) do |fe
   feed.updated @bugs.first.first_occurrence if @bugs.any?
 
   @bugs.each do |bug|
-    feed.entry(@bug,
+    feed.entry(bug,
                published: bug.first_occurrence,
                url:       project_environment_bug_url(@project, @environment, bug),
                id:        "project:#{@project.slug},environment:#{@environment.name},bug:#{bug.number}") do |entry|
       entry.title(
-          if @bug.special_file?
+          if bug.special_file?
             "#{bug.class_name} in #{bug.file}"
           else
             "#{bug.class_name} in #{bug.file}:#{bug.line}"


### PR DESCRIPTION
`@bug` should be just `bug`. 

Without this, when loading the atom feed, you get this error:

``` console
E, [2014-07-09T15:30:38.561285 #2948] ERROR -- : [failsafe_handler] 2014-07-09 15:30:38 -0700 - Original error: (NoMethodError) undefined method `special_file?' for nil:NilClass
E, [2014-07-09T15:30:38.561545 #2948] ERROR -- : [failsafe_handler]   /home/squash/squashapp/releases/20131005033134/app/views/bugs/index.atom.builder:25:in `block (3 levels) in _app_views_bugs_index_atom_builder__2938631946974487145_52828660'
  /home/squash/squashapp/shared/bundle/ruby/2.0.0/gems/actionpack-4.0.0/lib/action_view/helpers/atom_feed_helper.rb:196:in `block in entry'
  /home/squash/squashapp/shared/bundle/ruby/2.0.0/gems/builder-3.1.4/lib/builder/xmlbase.rb:170:in `call'
  /home/squash/squashapp/shared/bundle/ruby/2.0.0/gems/builder-3.1.4/lib/builder/xmlbase.rb:170:in `_nested_structures'
  /home/squash/squashapp/shared/bundle/ruby/2.0.0/gems/builder-3.1.4/lib/builder/xmlbase.rb:63:in `tag!'
  /home/squash/squashapp/shared/bundle/ruby/2.0.0/gems/builder-3.1.4/lib/builder/xmlbase.rb:88:in `method_missing'
  /home/squash/squashapp/shared/bundle/ruby/2.0.0/gems/actionpack-4.0.0/lib/action_view/helpers/atom_feed_helper.rb:181:in `entry'
  /home/squash/squashapp/releases/20131005033134/app/views/bugs/index.atom.builder:20:in `block (2 levels) in _app_views_bugs_index_atom_builder__2938631946974487145_52828660'
  /home/squash/squashapp/shared/bundle/ruby/2.0.0/gems/activerecord-4.0.0/lib/active_record/relation/delegation.rb:13:in `each'
  /home/squash/squashapp/shared/bundle/ruby/2.0.0/gems/activerecord-4.0.0/lib/active_record/relation/delegation.rb:13:in `each'
  /home/squash/squashapp/releases/20131005033134/app/views/bugs/index.atom.builder:19:in `block in _app_views_bugs_index_atom_builder__2938631946974487145_52828660'
  /home/squash/squashapp/shared/bundle/ruby/2.0.0/gems/actionpack-4.0.0/lib/action_view/helpers/atom_feed_helper.rb:123:in `block in atom_feed'
  /home/squash/squashapp/shared/bundle/ruby/2.0.0/gems/builder-3.1.4/lib/builder/xmlbase.rb:170:in `call'
  /home/squash/squashapp/shared/bundle/ruby/2.0.0/gems/builder-3.1.4/lib/builder/xmlbase.rb:170:in `_nested_structures'
  /home/squash/squashapp/shared/bundle/ruby/2.0.0/gems/builder-3.1.4/lib/builder/xmlbase.rb:63:in `tag!'
  /home/squash/squashapp/shared/bundle/ruby/2.0.0/gems/builder-3.1.4/lib/builder/xmlbase.rb:88:in `method_missing'
  /home/squash/squashapp/shared/bundle/ruby/2.0.0/gems/actionpack-4.0.0/lib/action_view/helpers/atom_feed_helper.rb:118:in `atom_feed'
  /home/squash/squashapp/releases/20131005033134/app/views/bugs/index.atom.builder:15:in `_app_views_bugs_index_atom_builder__2938631946974487145_52828660'
```
