### PR TITLE
Add support for authentication using the REMOTE_USER header

### DIFF
--- a/app/controllers/additions/remote_user_authentication_helpers.rb
+++ b/app/controllers/additions/remote_user_authentication_helpers.rb
@@ -1,0 +1,53 @@
+# Copyright 2013 Square Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+# Includes methods for authentication using headers from the request
+#
+# If this is the user's first time logging in, the User will be created for him
+# or her.
+
+module RemoteUserAuthenticationHelpers
+  extend ActiveSupport::Concern
+
+  included do
+    prepend_before_filter do
+      log_in
+    end
+  end
+
+  # Attempts to log in a user, given his/her credentials. If the login fails,
+  # the reason is logged and tagged with "[AuthenticationHelpers]". If the login
+  # is successful, the user ID is written to the session. Also creates or
+  # updates the User as appropriate.
+  #
+  # @return [true, false] Whether or not the login was successful.
+
+  def log_in *_
+    username = request.env['REMOTE_USER']
+
+    if username
+      user = find_or_create_user_from_env(username)
+      log_in_user user
+      return true
+    else
+      return false
+    end
+  end
+
+  private
+
+  def find_or_create_user_from_env(username)
+    User.where(username: username).create_or_update!
+  end
+end

--- a/app/models/additions/remote_user_authentication.rb
+++ b/app/models/additions/remote_user_authentication.rb
@@ -1,0 +1,23 @@
+# Copyright 2014 Square Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+module RemoteUserAuthentication
+  extend ActiveSupport::Concern
+
+  private
+
+  def create_primary_email
+    emails.create!(email: "#{username}@#{Squash::Configuration.mailer.domain}", primary: true)
+  end
+end

--- a/spec/controllers/additions/remote_user_authentication_helpers_spec.rb
+++ b/spec/controllers/additions/remote_user_authentication_helpers_spec.rb
@@ -1,0 +1,47 @@
+# Copyright 2014 Square Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+require 'spec_helper'
+
+if Squash::Configuration.authentication.strategy == 'remote_user'
+  class FakeController
+    def self.helper_method(*) end
+    def logger(*) Rails.logger end
+    def self.before_filter(*) end
+
+    include AuthenticationHelpers
+    include RemoteUserAuthenticationHelpers
+  end
+
+  describe RemoteUserAuthenticationHelpers do
+    before(:each) { @controller = FakeController.new }
+
+    describe "#log_in" do
+    #  before(:all) { @user = FactoryGirl.create(:user) }
+    before(:all) { @user = User.last }
+      before(:each) { ENV.delete 'REMOTE_USER' }
+
+      it "should accept a REMOTE_USER header" do
+        ENV['REMOTE_USER'] = @user.username
+        expect(@controller).to receive(:log_in_user).once.with(@user)
+        expect(@controller.log_in).to be_true
+      end
+
+      it "should not accept a missing header" do
+        expect(@controller).not_to receive :log_in_user
+        expect(@controller.log_in)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds support for authentication using the REMOTE_USER header, to support authn providers using a single-sign-on solution that sets that header, or something like `.htaccess`.
