### PR TITLE
Fix handling of nil values in PII filtering

### DIFF
--- a/lib/workers/occurrences_worker.rb
+++ b/lib/workers/occurrences_worker.rb
@@ -245,7 +245,7 @@ class OccurrencesWorker
       when Hash
         param.each do |representation, value|
           next if %w(language class_name).include?(representation)
-          param[representation] = filter_pii_string(value)
+          param[representation] = filter_pii_param(value)
         end
     end
   end

--- a/spec/lib/workers/occurrences_worker_spec.rb
+++ b/spec/lib/workers/occurrences_worker_spec.rb
@@ -298,6 +298,14 @@ RSpec.describe OccurrencesWorker do
           occ              = OccurrencesWorker.new(@params).perform
           expect(occ.ivars['email']).to eql('[EMAIL?]')
         end
+
+        it "should handle nils gracefully" do
+          @params['ivars'] = {"foo" => { "email" => nil },
+                              "other" => "something"}
+          expect {
+            occ            = OccurrencesWorker.new(@params).perform
+          }.not_to raise_error
+        end
       end
 
       it "should stick any attributes it doesn't recognize into the metadata attribute" do


### PR DESCRIPTION
I've had a couple errors come into Squash that it has failed halfway through creating (leaving my DB in a bad state). In tracing them back, what I _think_ happened is that `ivars` came in with a hash containing nil values, which causes the filtering method to fail.

I've fixed it here by simply recursing through hash structures, which seems like an elegant and safe way to make it happen.
